### PR TITLE
Add CTA in telegram message

### DIFF
--- a/src/Web.Api/Features/Telegram/ProcessMessage/ProcessTelegramMessageHandler.cs
+++ b/src/Web.Api/Features/Telegram/ProcessMessage/ProcessTelegramMessageHandler.cs
@@ -358,6 +358,10 @@ Last name: {message.From?.LastName}";
                 $"на сайте <a href=\"{salariesChartPageLink}\">{SalariesPageUrl}</a></em>";
         }
 
+        var ctaText = $"\n\n<em>Ещё не заполнял анкету? <a href=\"{salariesChartPageLink}\">Заполни сейчас</a></em>";
+
+        replyText += ctaText;
+
         return new TelegramBotReplyData(
             replyText.Trim(),
             new InlineKeyboardMarkup(


### PR DESCRIPTION
Add a CTA with the text "Ещё не заполнял анкету? Заполни сейчас" to the telegram message.

* Add a new variable `ctaText` with the CTA text and link.
* Append the `ctaText` to the `replyText` variable in the `ReplyWithSalariesAsync` method.
* Ensure the CTA text is added at the end of the `replyText` variable, before the closing tags.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Techinterview-space/web-api?shareId=XXXX-XXXX-XXXX-XXXX).