### PR TITLE
chore: bootstrap local dev environment prerequisites

### DIFF
--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -30,6 +30,7 @@
         <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="9.0.3" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4"  NoWarn="NU1510" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.0" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"  NoWarn="NU1510" />
         <PackageReference Include="Telegram.Bot" Version="22.7.6" />
         <PackageReference Include="AspNetCore.Aws.S3.Simple" Version="0.1.5" />

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -29,9 +29,9 @@
         <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
         <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="9.0.3" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
-        <PackageReference Include="System.Net.Http" Version="4.3.4"  NoWarn="NU1510" />
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.0" />
-        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"  NoWarn="NU1510" />
+        <PackageReference Include="System.Net.Http" Version="4.3.4" NoWarn="NU1510" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" NoWarn="NU1510" />
         <PackageReference Include="Telegram.Bot" Version="22.7.6" />
         <PackageReference Include="AspNetCore.Aws.S3.Simple" Version="0.1.5" />
         <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- bump `System.Security.Cryptography.Xml` to `10.0.7` in `Infrastructure` so `dotnet restore` succeeds under vulnerability-as-error policy
- install required local runtimes in this cloud VM (`dotnet` SDK and Docker tooling) to satisfy repo prerequisites
- run and verify core development stack: API, PostgreSQL, and Elasticsearch

## Runtime verification performed
- `dotnet restore` and `dotnet build` completed successfully
- started Docker daemon (compat mode) and launched `database.api`, `elasticsearch`, and `localstack` via compose
- started `Web.Api` with `dotnet run --project Web.Api` in tmux
- validated endpoints and backing services:
  - `https://localhost:5001/health` => HTTP 200 with `Database: Healthy`
  - `https://localhost:5001/swagger/v1/swagger.json` => HTTP 200
  - `pg_isready` inside `api-database` => accepting connections
  - Elasticsearch cluster health endpoint reachable

## Notes
- Localstack container in this environment is restart-looping due to missing `LOCALSTACK_AUTH_TOKEN` for the current image (`localstack/localstack`), so only Postgres + Elasticsearch are currently healthy from the compose dependencies.
- Verification logs are attached:
  - [dev_env_verification.log](https://cursor.com/agents/bc-187f7fae-e147-4704-a8f9-7fa3ed063c23/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_env_verification.log)
  - [api_startup_tmux.log](https://cursor.com/agents/bc-187f7fae-e147-4704-a8f9-7fa3ed063c23/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_startup_tmux.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-187f7fae-e147-4704-a8f9-7fa3ed063c23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-187f7fae-e147-4704-a8f9-7fa3ed063c23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

